### PR TITLE
update warnings about differ in signedness

### DIFF
--- a/README-FIX.md
+++ b/README-FIX.md
@@ -1,0 +1,8 @@
+# tiny-json update
+
+## update warnings:
+
+- tiny-json.c: In function 'parseString':
+- tiny-json.c:124:13: warning: pointer targets in return differ in signedness [-Wpointer-sign]
+- tiny-json.c:128:17: warning: pointer targets in passing argument 1 of 'getCharFromUnicode' differ in signedness [-Wpointer-sign]
+- tiny-json.c:105:13: note: expected 'const char *' but argument is of type 'unsigned char *'

--- a/tiny-json.c
+++ b/tiny-json.c
@@ -102,7 +102,7 @@ static bool isHexaDigit( unsigned char nibble ) {
   * @Param str Pointer to  first digit.
   * @retval '?' If the four characters are hexadecimal digits.
   * @retcal '\0' In other cases. */
-static char getCharFromUnicode( char const* str ) {
+static unsigned char getCharFromUnicode( unsigned char const* str ) {
     unsigned int i;
     for( i = 0; i < 4; ++i )
         if ( !isHexaDigit( str[i] ) )
@@ -116,12 +116,12 @@ static char getCharFromUnicode( char const* str ) {
   * @retval Pointer to first non white space after the string. If success.
   * @retval Null pointer if any error occur. */
 static char* parseString( char* str ) {
-    char* head = str;
-    char* tail = str;
+    unsigned char* head = (unsigned char*)str;
+    unsigned char* tail = (unsigned char*)str;
     for( ; *head >= ' '; ++head, ++tail ) {
         if ( *head == '\"' ) {
             *tail = '\0';
-            return ++head;
+            return (char*)++head;
         }
         if ( *head == '\\' ) {
             if ( *++head == 'u' ) {


### PR DESCRIPTION
Small fixes, update warnings:

tiny-json.c: In function 'parseString':
tiny-json.c:124:13: warning: pointer targets in return differ in signedness [-Wpointer-sign]
tiny-json.c:128:17: warning: pointer targets in passing argument 1 of 'getCharFromUnicode' differ in signedness [-Wpointer-sign]
tiny-json.c:105:13: note: expected 'const char *' but argument is of type 'unsigned char *'