### PR TITLE
Allow escape/special character in string

### DIFF
--- a/tiny-json.c
+++ b/tiny-json.c
@@ -130,7 +130,7 @@ static unsigned char getCharFromUnicode( unsigned char const* str ) {
 static char* parseString( char* str ) {
     unsigned char* head = (unsigned char*)str;
     unsigned char* tail = (unsigned char*)str;
-    for( ; *head >= ' '; ++head, ++tail ) {
+    for( ; *head; ++head, ++tail ) {
         if ( *head == '\"' ) {
             *tail = '\0';
             return (char*)++head;


### PR DESCRIPTION
Consider the case of PEM certificate.
This modification give it a chance to scan over those
escape characters. e.g.:
  '\t': 0x09
  '\n': 0x0A

Signed-off-by: Alamy Liu <alamy.liu@gmail.com>